### PR TITLE
-- Fix incorrect error checking of acquisition files prior to adding …

### DIFF
--- a/AcquiredData/Snirf/SnirfClass.m
+++ b/AcquiredData/Snirf/SnirfClass.m
@@ -405,6 +405,11 @@ classdef SnirfClass < AcqDataClass & FileLoadSaveClass
                 end
                 ii=ii+1;
             end
+            
+            % This is a required field. If it's empty means the whole snirf object is bad
+            if isempty(obj.data)
+                err = -1;
+            end
         end
         
         
@@ -449,6 +454,11 @@ classdef SnirfClass < AcqDataClass & FileLoadSaveClass
         function err = LoadProbe(obj, fileobj, ~)
             obj.probe = ProbeClass();
             err = obj.probe.LoadHdf5(fileobj, [obj.location, '/probe']);
+            
+            % This is a required field. If it's empty means the whole snirf object is bad
+            if isempty(obj.probe)
+                err = -1;
+            end
         end
         
         

--- a/DataTreeClass.m
+++ b/DataTreeClass.m
@@ -219,9 +219,11 @@ classdef DataTreeClass <  handle
                 obj.dirnameGroups{kk} = filesepStandard(groupDirs{kk},'full');
 
                 iGnew = length(obj.groups)+1;
-                
+                               
                 % Get file names and load them into DataTree
                 while length(obj.groups) < iGnew
+                    
+                    obj.logger.Write('\n');
                     
                     % Find group folder and it's acqiosition files                    
                     obj.files    = FileClass().empty();
@@ -239,7 +241,9 @@ classdef DataTreeClass <  handle
                         iter = iter+1;
                     end                    
                     obj.files = dataInit.files;
-                                        
+
+                    obj.logger.Write('\n');
+
                     % Print file and folder numbers stats
                     nfolders = length(dataInit.files)-dataInit.nfiles;
                     if nfolders==0


### PR DESCRIPTION
…them to dataTree data set.

-- If snirf file does not have data or probe flag it as an error in order to exclude it from dataTree data set.