### PR TITLE
-- Fix "Unable to resolve the name obj.cfg.GetValue." error at Homer3 startup. Static method cannot refer to object properties so instead use global cfg variable

### DIFF
--- a/AcquiredData/DataFiles/DataFilesClass.m
+++ b/AcquiredData/DataFiles/DataFilesClass.m
@@ -293,8 +293,6 @@ classdef DataFilesClass < handle
                     if strcmp(filesepStandard([ps,'/',fs], 'nameonly'), filesepStandard([pd,'/',fd], 'nameonly'))
                         found(ii) = 1;
                         break;
-                    else
-                        dbgpt = 1;
                     end
                 end
             end
@@ -320,6 +318,7 @@ classdef DataFilesClass < handle
             end
             
             % Try to create object of data type and load data into it
+            dataflag = false;
             for ii = 1:length(obj.files)
                 if obj.files(ii).isdir
                     continue;
@@ -328,10 +327,16 @@ classdef DataFilesClass < handle
                 eval( sprintf('o = %s(filename);', constructor) );
                 if o.GetError()<0
                     obj.logger.Write('FAILED error check:   %s will not be added to data set\n', filename);
-                    errorIdxs = [errorIdxs, ii];
+                    errorIdxs = [errorIdxs, ii]; %#ok<AGROW>
+                else
+                    dataflag = true;
                 end
             end
-            obj.files(errorIdxs) = [];
+            if dataflag==false
+                obj.files = FileClass.empty();
+            else
+            	obj.files(errorIdxs) = [];
+            end
         end
         
         

--- a/ProcStream/ProcResultClass.m
+++ b/ProcStream/ProcResultClass.m
@@ -171,7 +171,7 @@ classdef ProcResultClass < handle
             end
             [pname, fname] = fileparts(filename);
             options = 'nameonly:dir';
-            if ispathvalid(fname)
+            if ispathvalid(fname) || ispathvalid(['../', fname], 'dir')
                 % Case 1: Flat group dir structure                
                 if ispathvalid([filename, '.mat'])
                     % Loading: .mat file exists

--- a/ProcStream/ProcStreamClass.m
+++ b/ProcStream/ProcStreamClass.m
@@ -309,6 +309,16 @@ classdef ProcStreamClass < handle
         end
         
         
+        
+        % ----------------------------------------------------------------------------------        
+        function SaveInitOutput(obj, pathname, filename)
+            obj.output.SaveInit(pathname, filename)
+        end
+        
+        
+        
+        
+        
         % ----------------------------------------------------------------------------------        
         function nbytes = MemoryRequired(obj)
             nbytes(1) = obj.input.MemoryRequired();

--- a/TreeNodeClass.m
+++ b/TreeNodeClass.m
@@ -747,7 +747,7 @@ classdef TreeNodeClass < handle
                 return;
             end
             if optionExists(options, 'legacy')
-                outputDirname = '';
+                outputDirname = ''; %#ok<*PROPLC>
             else
                 outputDirname = obj.outputDirname;
             end

--- a/TreeNodeClass.m
+++ b/TreeNodeClass.m
@@ -154,6 +154,11 @@ classdef TreeNodeClass < handle
                 obj.iRun = obj2.iRun;
             end
             if ~isempty(obj2.procStream)
+                [pathname, filename] = fileparts([obj.path, obj.GetOutputFilename()]);                
+                if ispathvalid([filesepStandard(obj.path), obj.name], 'dir')
+                    pathname = [filesepStandard(pathname), obj.name];
+                end
+                obj.procStream.SaveInitOutput(pathname, filename);
                 obj.procStream.Copy(obj2.procStream, [obj.path, obj.GetOutputFilename()]);
             end
         end
@@ -829,7 +834,7 @@ classdef TreeNodeClass < handle
         
         % ------------------------------------------------------------
         function Print(obj, indent)
-            obj.logger.Write(sprintf('%s%s\n', blanks(indent), [obj.path, obj.procStream.output.SetFilename(obj.GetOutputFilename())] ));
+            obj.logger.Write('%s%s\n', blanks(indent), obj.procStream.output.SetFilename([obj.path, obj.GetOutputFilename()]) );
         end
 
         

--- a/TreeNodeClass.m
+++ b/TreeNodeClass.m
@@ -950,9 +950,11 @@ classdef TreeNodeClass < handle
                 
         % --------------------------------------------------------------------------------
         function out = GroupDataLoadWarnings()
+            global cfg
+            
             persistent v;
             if ~exist('arg','var')
-                v = obj.cfg.GetValue('Group Data Loading Warnings');
+                v = cfg.GetValue('Group Data Loading Warnings');
             elseif exist('arg','var')
                 v = arg;
             end


### PR DESCRIPTION
-- Fix "Unable to resolve the name obj.cfg.GetValue." error at Homer3 startup. Static method cannot refer to object properties so instead use global cfg variable
