### PR TITLE
Only save position fields that exist

### DIFF
--- a/AcquiredData/Snirf/ProbeClass.m
+++ b/AcquiredData/Snirf/ProbeClass.m
@@ -227,11 +227,15 @@ classdef ProbeClass < FileLoadSaveClass
             end     
             hdf5write_safe(fileobj, [location, '/wavelengths'], obj.wavelengths);
             hdf5write_safe(fileobj, [location, '/wavelengthsEmission'], obj.wavelengthsEmission);
-            hdf5write_safe(fileobj, [location, '/sourcePos2D'], obj.sourcePos2D(:,1:2), 'rw:2D');
-            hdf5write_safe(fileobj, [location, '/detectorPos2D'], obj.detectorPos2D(:,1:2), 'rw:2D');
+            if ~isempty(obj.sourcePos2D)
+                hdf5write_safe(fileobj, [location, '/sourcePos2D'], obj.sourcePos2D(:,1:2), 'rw:2D');
+                hdf5write_safe(fileobj, [location, '/detectorPos2D'], obj.detectorPos2D(:,1:2), 'rw:2D');
+            end
             hdf5write_safe(fileobj, [location, '/landmarkPos2D'], obj.landmarkPos2D, 'rw:2D');
-            hdf5write_safe(fileobj, [location, '/sourcePos3D'], obj.sourcePos3D, 'rw:3D');
-            hdf5write_safe(fileobj, [location, '/detectorPos3D'], obj.detectorPos3D, 'rw:3D');
+            if ~isempty(obj.sourcePos3D)
+                hdf5write_safe(fileobj, [location, '/sourcePos3D'], obj.sourcePos3D, 'rw:3D');
+                hdf5write_safe(fileobj, [location, '/detectorPos3D'], obj.detectorPos3D, 'rw:3D');
+            end
             hdf5write_safe(fileobj, [location, '/landmarkPos3D'], obj.landmarkPos3D, 'rw:3D');
             hdf5write_safe(fileobj, [location, '/frequencies'], obj.frequencies);
             hdf5write_safe(fileobj, [location, '/timeDelays'], obj.timeDelays);


### PR DESCRIPTION
`sourcePos2D` and `sourcePos3D` do not always exist in SNIRF files. The [specification requires only one of these to exist](https://github.com/fNIRS/snirf/blob/master/snirf_specification.md#nirsiprobesourcepos2d).

I ran in to a bug where I loaded a SNIRF file that only contained 3D coordinates, then when I went to save the file I got an error. 

This PR changes the probe saving function to only save the 2D or 3D positions if they are in the snirf object.