### PR TITLE
Handle cell strings in SNIRF files

### DIFF
--- a/AcquiredData/DataFiles/Hdf5/HDF5_PostProcessing.m
+++ b/AcquiredData/DataFiles/Hdf5/HDF5_PostProcessing.m
@@ -13,4 +13,8 @@ if ischar(val) && ~iscell(val0)
     val = convertHDF5StrToMatlabStr(val);
 elseif ischar(val)
     val = convertHDF5StrToMatlabStr(val, 'cell');
+elseif iscell(val) && length(val) == 1
+    val = val{1};
+elseif iscell(val) && length(val) > 1
+    val = {val{:}}';
 end


### PR DESCRIPTION
There is some ambiguity about how strings should be encoded in SNIRF files ([see discussion here](https://github.com/fNIRS/snirf/issues/72)). There was talk about enforcing variable HDF5 length strings in SNIRF (https://github.com/fNIRS/snirf/issues/72#issuecomment-912204459) but that has not been confirmed.

Files exported in SNIRF format by MNE-Python use variable length strings. Which is loaded in MATLAB as some sort of cell structure (excuse my rusty matlab skills).

This PR aims to enable loading of SNIRF files from python with HDF5 variable length strings in to HOMER.  With this PR I can load [this data](https://github.com/rob-luke/BIDS-NIRS-Tapping) (which is valid according to https://github.com/andyzjc/snirf_validator) using the following script and the output looks sane.

```matlab
filenm = '.../Repositories/BIDS-NIRS-Tapping/sub-03/nirs/sub-03_task-Tapping_nirs.snirf'

snirf = SnirfLoad( filenm )

size(snirf.data.dataTimeSeries)

snirf.probe

snirf.metaDataTags.tags
```

which results in

```text

snirf = 

  SnirfClass with properties:

    formatVersion: '1.0'
     metaDataTags: [1×1 MetaDataTagsClass]
             data: [1×1 DataClass]
             stim: [1×4 StimClass]
            probe: [1×1 ProbeClass]
              aux: [1×0 AuxClass]


ans =

       18875          56


ans = 

  ProbeClass with properties:

                   wavelengths: [2×1 double]
           wavelengthsEmission: []
                   sourcePos2D: [0×1 double]
                 detectorPos2D: [0×1 double]
                 landmarkPos2D: []
                 landmarkPos3D: [31×3 double]
                   sourcePos3D: [8×3 double]
                 detectorPos3D: [16×3 double]
                   frequencies: []
                    timeDelays: []
               timeDelayWidths: []
                  momentOrders: []
         correlationTimeDelays: []
    correlationTimeDelayWidths: []
                  sourceLabels: {8×1 cell}
                detectorLabels: {16×1 cell}
                landmarkLabels: {31×1 cell}


ans = 

  struct with fields:

        DateOfBirth: '1994-01-03'
      FrequencyUnit: 'Hz'
         LengthUnit: 'm'
     MNE_coordFrame: 4
    MeasurementDate: '2020-01-03'
    MeasurementTime: '13:20:38Z'
          SubjectID: 'P3'
           TimeUnit: 's'
                sex: '2'

```

I have tried to make the minimal change to enable this, however, this means that I am modifying a low level function which may have unexpected consequences.  I am unsure how to test I haven't broken other aspects of the code base. The only test I have run is to load some data exported from NIRx Aurora in SNIRF format and confirmed that it is the same with and without this PR change. Please let me know if there is a better way to achieve loading of these files or how I can test I havent broken anything else.