### PR TITLE
Add methods ApplyParamEditsToAll to be able to apply param value edits to all data tree elements

### DIFF
--- a/DataTreeClass.m
+++ b/DataTreeClass.m
@@ -707,6 +707,21 @@ classdef DataTreeClass <  handle
         end
         
         
+        
+        % --------------------------------------------------------------------------
+        function ApplyParamEditsToAll(obj, iFcall, iParam, val)
+            for iG = 1:length(obj.groups)                
+                if     obj.currElem.iSubj>0  && obj.currElem.iSess==0 && obj.currElem.iRun==0
+                    obj.groups(iG).ApplyParamEditsToAllSubjects(iFcall, iParam, val);
+                elseif obj.currElem.iSubj>0  && obj.currElem.iSess>0 && obj.currElem.iRun==0
+                    obj.groups(iG).ApplyParamEditsToAllSessions(iFcall, iParam, val);
+                elseif obj.currElem.iSubj>0  && obj.currElem.iSess>0 && obj.currElem.iRun>0
+                    obj.groups(iG).ApplyParamEditsToAllRuns(iFcall, iParam, val);
+                end
+            end
+        end
+        
+        
     end
     
 end

--- a/GroupClass.m
+++ b/GroupClass.m
@@ -1045,6 +1045,31 @@ classdef GroupClass < TreeNodeClass
                 name = sprintf('%s%s%d', base, addon, n);
             end
         end
+       
+        
+        
+        % --------------------------------------------------------------------------
+        function ApplyParamEditsToAllSubjects(obj, iFcall, iParam, val)
+            for jj = 1:length(obj.subjs)
+                obj.subjs(jj).procStream.EditParam(iFcall, iParam, val);
+            end
+        end
+        
+        
+        % --------------------------------------------------------------------------
+        function ApplyParamEditsToAllSessions(obj, iFcall, iParam, val)
+            for jj = 1:length(obj.subjs)
+                obj.subjs(jj).ApplyParamEditsToAllSessions(iFcall, iParam, val);
+            end
+        end
+        
+        
+        % --------------------------------------------------------------------------
+        function ApplyParamEditsToAllRuns(obj, iFcall, iParam, val)
+            for jj = 1:length(obj.subjs)
+                obj.subjs(jj).ApplyParamEditsToAllRuns(iFcall, iParam, val);
+            end
+        end
         
     end
     

--- a/SessClass.m
+++ b/SessClass.m
@@ -657,6 +657,14 @@ classdef SessClass < TreeNodeClass
             end
         end
         
+        
+         % --------------------------------------------------------------------------
+        function ApplyParamEditsToAllRuns(obj, iFcall, iParam, val)
+            for jj = 1:length(obj.runs)
+                obj.runs(jj).procStream.EditParam(iFcall, iParam, val);
+            end
+        end
+                
     end
         
     

--- a/SubjClass.m
+++ b/SubjClass.m
@@ -453,6 +453,21 @@ classdef SubjClass < TreeNodeClass
         end
         
                
+         % --------------------------------------------------------------------------
+        function ApplyParamEditsToAllSessions(obj, iFcall, iParam, val)
+            for jj = 1:length(obj.sess)
+                obj.sess(jj).procStream.EditParam(iFcall, iParam, val);
+            end
+        end
+        
+        
+        % --------------------------------------------------------------------------
+        function ApplyParamEditsToAllRuns(obj, iFcall, iParam, val)
+            for jj = 1:length(obj.sess)
+                obj.sess(jj).ApplyParamEditsToAllRuns(iFcall, iParam, val);
+            end
+        end
+        
     end
     
     
@@ -694,7 +709,7 @@ classdef SubjClass < TreeNodeClass
                 obj.sess(ii).ListOutputFilenames(options);
             end
         end
-        
+                
     end
         
     

--- a/TreeNodeClass.m
+++ b/TreeNodeClass.m
@@ -753,6 +753,31 @@ classdef TreeNodeClass < handle
         
         
         % ----------------------------------------------------------------------------------
+        function ApplyParamEditToAll(obj, iFcall, iParam, val)
+            % Figure out which level we are: group, subj, sess, or run
+            if obj.iSubj==0 && obj.iSess==0 && obj.iRun==0
+                for ii = 1:length(obj.subjs)
+                    obj.subjs(ii).procStream.EditParam(iFcall, iParam, val);
+                end
+             elseif obj.iSubj>0 && obj.iSess>0 && obj.iRun==0
+                for ii = 1:length(obj.subjs)
+                    for jj = 1:length(obj.subjs(ii).sess)
+                        obj.subjs(ii).sess(jj).procStream.EditParam(iFcall, iParam, val);
+                    end
+                end
+            elseif obj.iSubj>0 && obj.iSess>0 && obj.iRun>0
+                for ii = 1:length(obj.subjs)
+                    for jj = 1:length(obj.subjs(ii).sess)
+                        for kk = 1:length(obj.subjs(ii).sess(jj).runs)
+                            obj.subjs(ii).sess(jj).runs(kk).procStream.EditParam(iFcall, iParam, val);
+                        end
+                    end
+                end
+            end
+        end
+        
+        
+        % ----------------------------------------------------------------------------------
         function tblcells = ExportMeanHRF(~, ~, ~)
             tblcells = {};
         end
@@ -989,7 +1014,6 @@ classdef TreeNodeClass < handle
             end
             out = v;
         end
-        
         
     end
     


### PR DESCRIPTION
-- Add methods ApplyParamEditsToAll to be able to apply param value edits to all data tree elements that belong to the same level such as subject, run, etc. This is part of a fix to Homer3's ProcStreamOptionsGUI which lacked BIDS support when editing proc stream parameter values